### PR TITLE
Update app dependencies with migration to Firebase Crashlytics

### DIFF
--- a/alertdialog/build.gradle
+++ b/alertdialog/build.gradle
@@ -42,15 +42,15 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
 
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    androidTestImplementation 'androidx.test:core:1.2.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test:core:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
 
-    implementation 'com.google.android.material:material:1.1.0'
-    implementation 'androidx.core:core-ktx:1.3.0'
+    implementation 'com.google.android.material:material:1.2.1'
+    implementation 'androidx.core:core-ktx:1.3.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/alertdialog/build.gradle
+++ b/alertdialog/build.gradle
@@ -18,12 +18,10 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
-
+    compileSdkVersion 30
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,8 +105,8 @@ dependencies {
     implementation 'org.koin:koin-androidx-viewmodel:2.0.1'
     implementation 'org.koin:koin-androidx-scope:2.0.1'
 
-    implementation 'com.google.firebase:firebase-analytics:17.4.4'
-    implementation 'com.crashlytics.sdk.android:crashlytics:2.10.1'
+    implementation 'com.google.firebase:firebase-analytics:17.5.0'
+    implementation 'com.google.firebase:firebase-crashlytics:17.2.2'
 
     implementation 'com.jakewharton.timber:timber:4.7.1'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,27 +78,27 @@ dependencies {
     implementation project(':alertdialog')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.3.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.core:core-ktx:1.3.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    androidTestImplementation 'androidx.test:core:1.2.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test:core:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
 
     implementation "com.github.skydoves:powermenu:2.1.0"
     implementation 'com.github.ypicoleal:FancyTab:0.0.2'
     implementation 'com.github.florent37:kotlinpleaseanimate:1.0.2'
     implementation 'com.github.alxrm:audiowave-progressbar:0.9.2'
     implementation 'com.budiyev.android:circular-progress-bar:1.2.2'
-    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.google.code.gson:gson:2.8.6'
 
     // Coroutines
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.3"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7"
 
     // Koin
     implementation "org.koin:koin-android:2.0.1"
@@ -111,11 +111,11 @@ dependencies {
     implementation 'com.jakewharton.timber:timber:4.7.1'
 
     // JAudio Tagger
-    implementation 'net.jthink:jaudiotagger:2.2.3'
+    implementation 'net.jthink:jaudiotagger:2.2.5'
 
 
     //Glide
-    implementation 'com.github.bumptech.glide:glide:4.9.0'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.9.0'
+    implementation 'com.github.bumptech.glide:glide:4.11.0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.11.0'
     implementation 'androidx.palette:palette-ktx:1.0.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,12 +24,11 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'com.google.firebase.crashlytics'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
+    compileSdkVersion 30
     defaultConfig {
         applicationId "com.crrl.beatplayer"
         minSdkVersion 24
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 100
         versionName "1.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/crrl/beatplayer/utils/ReleaseTree.kt
+++ b/app/src/main/java/com/crrl/beatplayer/utils/ReleaseTree.kt
@@ -13,18 +13,21 @@
 
 package com.crrl.beatplayer.utils
 
-import com.crashlytics.android.Crashlytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import org.jetbrains.annotations.NotNull
 import timber.log.Timber
 
 class ReleaseTree : @NotNull Timber.Tree() {
     override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+        val crashlytics = FirebaseCrashlytics.getInstance()
         try {
             if (t != null) {
-                Crashlytics.setString("beatplayer_crash_tag", tag)
-                Crashlytics.logException(t)
+                if (tag != null) {
+                    crashlytics.setCustomKey("beatplayer_crash_tag", tag)
+                }
+                crashlytics.log(t.toString())
             } else {
-                Crashlytics.log(priority, tag, message)
+                crashlytics.log(priority.toString() + tag + message)
             }
         } catch (e: IllegalStateException) {
             e.printStackTrace()

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.1'
-        classpath 'com.google.gms:google-services:4.3.3'
+        classpath 'com.google.gms:google-services:4.3.4'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.1'
         classpath 'com.google.gms:google-services:4.3.4'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.2.0'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.72'
+    ext.kotlin_version = '1.4.10'
     repositories {
         google()
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         maven { url 'https://dl.bintray.com/ijabz/maven' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.0.1'
         classpath 'com.google.gms:google-services:4.3.3'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 #Fri May 01 20:04:47 CST 2020
-kotlin_version=1.3.72
+kotlin_version=1.4.10
 kotlin.code.style=official
 android.enableJetifier=true
 org.gradle.jvmargs=-Xmx1024M -Dkotlin.daemon.jvm.options\="-Xmx1024M"


### PR DESCRIPTION
**Summary of PR**
- Updated global app dependencies
- Started support for Android SDK 30
- Migration to Firebase Crashlytics 
(reason for migration is because of the deprecation of the current crashlytics sdk and Google officially dropping support for it)